### PR TITLE
Added PID - support for Monit - process monitoring

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,15 @@
-# ver. 0.0.7
+# ver. 0.0.8
 import time
-
+import os
 import paho.mqtt.client as mqtt
 import config.config as config
 import config.registers as registers
 from pysolarmanv5.pysolarmanv5 import PySolarmanV5
 import logging
+
+pid = str(os.getpid())
+with open("/tmp/main.pid", "w") as f:
+    f.write(pid)
 
 topics = []
 debug = 0


### PR DESCRIPTION
I found that the `main.py` is occasionally crashing or not starting for various reasons. As python scripts have no identifiable PID, the support was added to work with service monitoring applications like `monit`.

```
sudo apt-get update
sudo apt-get install monit
```